### PR TITLE
The bat-scripts now recursively make and restore from backups.

### DIFF
--- a/tools/mapmerge/1prepare_map.bat
+++ b/tools/mapmerge/1prepare_map.bat
@@ -1,6 +1,6 @@
 cd ../../maps
 
-FOR %%f IN (*.dmm) DO (
+FOR /R %%f IN (*.dmm) DO (
   copy %%f %%f.backup
 )
 

--- a/tools/mapmerge/2clean_map.bat
+++ b/tools/mapmerge/2clean_map.bat
@@ -1,8 +1,7 @@
-SET z_levels=6
-cd 
+cd ../../maps
 
-FOR %%f IN (../../maps/*.dmm) DO (
-  java -jar MapPatcher.jar -clean ../../maps/%%f.backup ../../maps/%%f ../../maps/%%f
+FOR /R %%f IN (*.dmm) DO (
+  java -jar ../tools/mapmerge/MapPatcher.jar -clean %%f.backup %%f %%f
 )
 
 pause


### PR DESCRIPTION
clean_map_git.sh still remains.
As currently written it's the line ```git show HEAD:maps/$MAPNAME > tmp.dmm``` that complicates things, as the ```:maps/```-part is the relative path between the base git repository folder, and the current file's location.