### PR TITLE
fix #13341

### DIFF
--- a/code/_helpers/lists.dm
+++ b/code/_helpers/lists.dm
@@ -446,7 +446,7 @@ proc/listclearnulls(list/list)
 // Insert an object into a sorted list, preserving sortedness
 /proc/dd_insertObjectList(var/list/L, var/O)
 	var/min = 1
-	var/max = L.len
+	var/max = L.len + 1
 	var/Oval = O:dd_SortValue()
 
 	while(1)


### PR DESCRIPTION
Oops.

Fixes #13341.

```
Picked: 5
Picked: 1
Picked: 8
Picked: 7
Picked: 0
Picked: 6
Picked: 9
Picked: 4
Picked: 2
Picked: 3
Sorted output:
    0
    1
    2
    3
    4
    5
    6
    7
    8
    9
```
